### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict'
 const request = require('request')
+const urlLib = require('url');
 var browser = request.defaults({
   headers: {'User-Agent': 'The Botfather NodeJS module (https://www.npmjs.com/package/ethermine-api)'}
 })
@@ -178,11 +179,13 @@ module.exports = class Ethermine {
       })
     }
     setAPIurl(url = 'https://api.ethermine.org', callback){
-      let validapi = ['https://api-ergo.flypool.org', 'https://api-etc.ethermine.org', 'https://api-zcash.flypool.org', 'https://api-ycash.flypool.org', 'https://api-beam.flypool.org', 'https://api-ravencoin.flypool.org', 'https://api.ethpool.org'];
-      if (validapi.indexOf(url) > -1) {
+      const urlLib = require('url');
+      let validHosts = ['api-ergo.flypool.org', 'api-etc.ethermine.org', 'api-zcash.flypool.org', 'api-ycash.flypool.org', 'api-beam.flypool.org', 'api-ravencoin.flypool.org', 'api.ethpool.org'];
+      let parsedUrl = urlLib.parse(url);
+      if (validHosts.includes(parsedUrl.host)) {
         this.apiurl = url;
         callback(false, 'API URL set to: ' + url);
-      }else{
+      } else {
         callback(true, 'API not supported');
       }
     }


### PR DESCRIPTION
Fixes [https://github.com/Hubspot-Inc/ethermine-api/security/code-scanning/1](https://github.com/Hubspot-Inc/ethermine-api/security/code-scanning/1)

To fix the problem, we need to ensure that the URL is parsed and its host is explicitly checked against a whitelist of allowed hosts. This can be achieved by using the `url` module to parse the URL and then comparing the host component with the allowed hosts.

- Parse the URL using the `url` module to extract the host component.
- Check if the host is in the list of allowed hosts.
- Update the `setAPIurl` method to use this new validation approach.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
